### PR TITLE
Kill trailing whitespace

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,21 +1,21 @@
 <?php
 /**
- * The functions file is used to initialize everything in the theme.  It controls how the theme is loaded and 
- * sets up the supported features, default actions, and default filters.  If making customizations, users 
- * should create a child theme and make changes to its functions.php file (not this one).  Friends don't let 
+ * The functions file is used to initialize everything in the theme.  It controls how the theme is loaded and
+ * sets up the supported features, default actions, and default filters.  If making customizations, users
+ * should create a child theme and make changes to its functions.php file (not this one).  Friends don't let
  * friends modify parent theme files. ;)
  *
  * Child themes should do their setup on the 'after_setup_theme' hook with a priority of 11 if they want to
  * override parent theme features.  Use a priority of 9 if wanting to run before the parent theme.
  *
- * This program is free software; you can redistribute it and/or modify it under the terms of the GNU 
- * General Public License as published by the Free Software Foundation; either version 2 of the License, 
+ * This program is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation; either version 2 of the License,
  * or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *
- * You should have received a copy of the GNU General Public License along with this program; if not, write 
+ * You should have received a copy of the GNU General Public License along with this program; if not, write
  * to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  *
  * @package    HybridBase
@@ -49,27 +49,27 @@ function hybrid_base_theme_setup() {
 	$prefix = hybrid_get_prefix();
 
 	/* Register menus. */
-	add_theme_support( 
-		'hybrid-core-menus', 
-		array( 'primary', 'secondary', 'subsidiary' ) 
+	add_theme_support(
+		'hybrid-core-menus',
+		array( 'primary', 'secondary', 'subsidiary' )
 	);
 
 	/* Register sidebars. */
-	add_theme_support( 
-		'hybrid-core-sidebars', 
-		array( 'primary', 'secondary', 'subsidiary' ) 
+	add_theme_support(
+		'hybrid-core-sidebars',
+		array( 'primary', 'secondary', 'subsidiary' )
 	);
 
 	/* Load scripts. */
-	add_theme_support( 
-		'hybrid-core-scripts', 
-		array( 'comment-reply' ) 
+	add_theme_support(
+		'hybrid-core-scripts',
+		array( 'comment-reply' )
 	);
 
 	/* Load styles. */
-	add_theme_support( 
-		'hybrid-core-styles', 
-		array( '25px', 'gallery', 'parent', 'style' ) 
+	add_theme_support(
+		'hybrid-core-styles',
+		array( '25px', 'gallery', 'parent', 'style' )
 	);
 
 	/* Load widgets. */
@@ -82,10 +82,10 @@ function hybrid_base_theme_setup() {
 	add_theme_support( 'hybrid-core-template-hierarchy' );
 
 	/* Enable theme layouts (need to add stylesheet support). */
-	add_theme_support( 
-		'theme-layouts', 
-		array( '1c', '2c-l', '2c-r' ), 
-		array( 'default' => '1c', 'customizer' => true ) 
+	add_theme_support(
+		'theme-layouts',
+		array( '1c', '2c-l', '2c-r' ),
+		array( 'default' => '1c', 'customizer' => true )
 	);
 
 	/* Allow per-post stylesheets. */
@@ -110,9 +110,9 @@ function hybrid_base_theme_setup() {
 	add_theme_support( 'automatic-feed-links' );
 
 	/* Post formats. */
-	add_theme_support( 
-		'post-formats', 
-		array( 'aside', 'audio', 'chat', 'image', 'gallery', 'link', 'quote', 'status', 'video' ) 
+	add_theme_support(
+		'post-formats',
+		array( 'aside', 'audio', 'chat', 'image', 'gallery', 'link', 'quote', 'status', 'video' )
 	);
 
 	/* Add support for a custom header image. */
@@ -121,7 +121,7 @@ function hybrid_base_theme_setup() {
 		array( 'header-text' => false ) );
 
 	/* Custom background. */
-	add_theme_support( 
+	add_theme_support(
 		'custom-background',
 		array( 'default-color' => 'ffffff' )
 	);
@@ -136,10 +136,10 @@ function hybrid_base_theme_setup() {
 	/****************************/
 }
 
-/* === HYBRID CORE 1.6 CHANGES. === 
+/* === HYBRID CORE 1.6 CHANGES. ===
  *
- * The following changes are slated for Hybrid Core version 1.6 to make it easier for 
- * theme developers to build awesome HTML5 themes. The code will be removed once 1.6 
+ * The following changes are slated for Hybrid Core version 1.6 to make it easier for
+ * theme developers to build awesome HTML5 themes. The code will be removed once 1.6
  * is released.
  */
 
@@ -208,7 +208,7 @@ function hybrid_base_theme_setup() {
 	}
 
 	/**
-	 * Adds an infinity character "&#8734;" to the end of the post content on 'aside' posts.  This 
+	 * Adds an infinity character "&#8734;" to the end of the post content on 'aside' posts.  This
 	 * is from version 0.1.1 of the Post Format Tools extension.
 	 *
 	 * @since  0.1.0

--- a/loop.php
+++ b/loop.php
@@ -6,7 +6,7 @@
 
 		<?php
 		      /* Update when Hybrid Core 1.6 is released. This function will no longer be available. */
-		      hybrid_base_get_content_template(); // Loads the content template. 
+		      hybrid_base_get_content_template(); // Loads the content template.
 		?>
 
 		<?php if ( is_singular() ) { ?>


### PR DESCRIPTION
Minor cleanup with my regular workhorse

```
alias find-kill-trailing-whitespace='find . -path ./.git -prune -o \( -name "*.js" -o -name "*.php" -o -name "*.css" \) -exec sed -i "s/ *$//" {} \;'
```

It would be awesome if the theme (or author) would drop tabs in favor of spaces (:set expandtab ftw!), as well, but I'm not counting on it :)
